### PR TITLE
[LEARNCO-201] Adding support for a --lesson-uuid parameter

### DIFF
--- a/bin/learn-open
+++ b/bin/learn-open
@@ -2,11 +2,12 @@
 
 require 'learn_open'
 
-lesson, editor_specified, next_lesson, clone_only = LearnOpen::ArgumentParser.new(ARGV).execute
+lesson, editor_specified, next_lesson, clone_only, lesson_uuid = LearnOpen::ArgumentParser.new(ARGV).execute
 
 LearnOpen::Opener.run(
   lesson: lesson,
   editor_specified: editor_specified,
   get_next_lesson: next_lesson,
-  clone_only: clone_only
+  clone_only: clone_only,
+  lesson_uuid: lesson_uuid
 )

--- a/lib/learn_open/argument_parser.rb
+++ b/lib/learn_open/argument_parser.rb
@@ -21,6 +21,10 @@ module LearnOpen
         opts.on("--clone-only", "only download files. No shell") do |co|
           options[:clone_only] = co
         end
+
+        opts.on("--lesson-uuid=UUID", "opens the lab by lesson uuid") do |uuid|
+          options[:lesson_uuid] = uuid
+        end
       end.parse(args)
       options[:lesson_name] = rest.first
       options
@@ -32,17 +36,22 @@ module LearnOpen
       editor.split.first
     end
 
+    def empty?(val)
+      val == '' || val.nil?
+    end
+
     def execute
       cli_args = parse
 
-      editor = cli_args[:editor].empty? ? learn_config_editor : cli_args[:editor]
+      editor = empty?(cli_args[:editor]) ? learn_config_editor : cli_args[:editor]
       cli_args.merge!(editor: editor)
 
       [
         cli_args[:lesson_name],
         cli_args[:editor],
         cli_args[:next],
-        cli_args[:clone_only]
+        cli_args[:clone_only],
+        cli_args[:lesson_uuid]
       ]
     end
   end

--- a/lib/learn_open/lessons/ios_lesson.rb
+++ b/lib/learn_open/lessons/ios_lesson.rb
@@ -3,7 +3,7 @@ module LearnOpen
     class IosLesson < BaseLesson
       def self.detect(lesson)
         languages = Hash(lesson.dot_learn)[:languages]
-        (languages & ["swift", "objc"]).any?
+        languages.kind_of?(Array) && (languages & ["swift", "objc"]).any?
       end
 
       def open(environment, editor, clone_only)

--- a/spec/learn_open/opener_spec.rb
+++ b/spec/learn_open/opener_spec.rb
@@ -22,21 +22,26 @@ describe LearnOpen::Opener do
 
   context "Initializer" do
     it "sets the lesson" do
-      opener = LearnOpen::Opener.new("ttt-2-board-rb-v-000","", false, false)
+      opener = LearnOpen::Opener.new("ttt-2-board-rb-v-000","", false, false, lesson_uuid: nil)
       expect(opener.target_lesson).to eq("ttt-2-board-rb-v-000")
     end
     it "sets the editor" do
-      opener = LearnOpen::Opener.new("", "atom", false, false)
+      opener = LearnOpen::Opener.new("", "atom", false, false, lesson_uuid: nil)
       expect(opener.editor).to eq("atom")
     end
     it "sets the whether to open the next lesson or not" do
-      opener = LearnOpen::Opener.new("", "", true, false)
+      opener = LearnOpen::Opener.new("", "", true, false, lesson_uuid: nil)
       expect(opener.get_next_lesson).to eq(true)
     end
 
     it "sets the clone only options" do
-      opener = LearnOpen::Opener.new("", "", true, true)
+      opener = LearnOpen::Opener.new("", "", true, true, lesson_uuid: nil)
       expect(opener.clone_only).to eq(true)
+    end
+
+    it "sets the lesson_uuid option" do
+      opener = LearnOpen::Opener.new("", "", true, true, lesson_uuid: 'im-a-uuid')
+      expect(opener.lesson_uuid).to eq('im-a-uuid')
     end
   end
 


### PR DESCRIPTION
Adds support for a `--lesson-uuid` param which will request a serialized lesson using the 2U endpoint.